### PR TITLE
return values instead of populating parameters

### DIFF
--- a/examples/sai2/01-load_world_and_simulate/main.cpp
+++ b/examples/sai2/01-load_world_and_simulate/main.cpp
@@ -43,13 +43,9 @@ int main(int argc, char** argv) {
 
 	// while window is open:
 	while (graphics->isWindowOpen()) {
-		// read joint position from simulation
-		Eigen::VectorXd robot_q;
-		sim->getJointPositions(robot_name, robot_q);
-		// update graphics. this automatically waits for the correct amount of
-		// time
-		graphics->updateRobotGraphics(robot_name, robot_q);
-		graphics->updateDisplayedWorld();
+		// update graphics from simulation.
+		graphics->updateRobotGraphics(robot_name, sim->getJointPositions(robot_name));
+		graphics->renderGraphicsWorld();
 
 		if(counter == 300) {
 			cout << "\nenabling gravity compensation\n" << endl;

--- a/examples/sai2/02-fixed_joint/main.cpp
+++ b/examples/sai2/02-fixed_joint/main.cpp
@@ -39,17 +39,12 @@ int main(int argc, char** argv) {
 	// start the simulation
 	thread sim_thread(simulation, sim);
 
-	// while window is open:
 	while (graphics->isWindowOpen()) {
 		for (const auto& robot_name : sim->getRobotNames()) {
-			Eigen::VectorXd robot_q;
-			sim->getJointPositions(
-				robot_name, robot_q);  // read the joint values from simulation
-			graphics->updateRobotGraphics(
-				robot_name,
-				robot_q);  // update the graphics with those joint values
+			graphics->updateRobotGraphics(robot_name,
+										  sim->getJointPositions(robot_name));
 		}
-		graphics->updateDisplayedWorld();
+		graphics->renderGraphicsWorld();
 	}
 
 	// stop simulation

--- a/examples/sai2/03-spherical_joint_and_ui_interactions/main.cpp
+++ b/examples/sai2/03-spherical_joint_and_ui_interactions/main.cpp
@@ -15,7 +15,6 @@ const string camera_name = "camera_fixed";
 bool fSimulationRunning = false;
 
 std::map<std::string, Eigen::VectorXd> ui_torques;
-std::map<std::string, Eigen::VectorXd> robot_q;
 
 // sim
 void simulation(std::shared_ptr<Sai2Simulation::Sai2Simulation> sim);
@@ -28,7 +27,6 @@ int main(int argc, char** argv) {
 	std::vector<std::string> robot_names = sim->getRobotNames();
 	for (const auto& robot_name : robot_names) {
 		ui_torques[robot_name] = Eigen::VectorXd::Zero(sim->dof(robot_name));
-		robot_q[robot_name] = Eigen::VectorXd::Zero(sim->qSize(robot_name));
 	}
 
 	// load graphics scene
@@ -55,14 +53,13 @@ int main(int argc, char** argv) {
 	while (graphics->isWindowOpen()) {
 		// update graphics from latest simulation config
 		for (const auto& robot_name : robot_names) {
-			sim->getJointPositions(robot_name, robot_q[robot_name]);
-			graphics->updateRobotGraphics(robot_name, robot_q[robot_name]);
+			graphics->updateRobotGraphics(robot_name, sim->getJointPositions(robot_name));
 		}
-		graphics->updateDisplayedWorld();
+		graphics->renderGraphicsWorld();
 
 		// get the torques applied by the user via the ui
 		for (const auto& robot_name : robot_names) {
-			graphics->getUITorques(robot_name, ui_torques[robot_name]);
+			ui_torques[robot_name] = graphics->getUITorques(robot_name);
 		}
 	}
 

--- a/examples/sai2/04-joint_limits_and_damping/main.cpp
+++ b/examples/sai2/04-joint_limits_and_damping/main.cpp
@@ -47,15 +47,10 @@ int main(int argc, char** argv) {
 		// apply joint torque
 		sim->setJointTorques(robot_name, torques);
 
-		// get joint positions from simulation
-		Eigen::VectorXd robot_q;
-		sim->getJointPositions(robot_name, robot_q);
-
-		// update graphics. this automatically waits for the correct amount of
-		// time
-		graphics->updateRobotGraphics(robot_name, robot_q);
-		graphics->updateDisplayedWorld();
-		graphics->getUITorques(robot_name, torques);
+		// update graphics.
+		graphics->updateRobotGraphics(robot_name, sim->getJointPositions(robot_name));
+		graphics->renderGraphicsWorld();
+		torques = graphics->getUITorques(robot_name);
 	}
 
 	// stop simulation

--- a/examples/sai2/05-pause_sim/main.cpp
+++ b/examples/sai2/05-pause_sim/main.cpp
@@ -36,13 +36,11 @@ int main() {
 
 		// update graphics
 		for (const auto name : robot_names) {
-			Eigen::VectorXd q_robot;
-			sim->getJointPositions(name, q_robot);
-			graphics->updateRobotGraphics(name, q_robot);
+			graphics->updateRobotGraphics(name, sim->getJointPositions(name));
 		}
-		graphics->updateDisplayedWorld();
+		graphics->renderGraphicsWorld();
 
-		if (loop_counter == 700) {
+		if (loop_counter == 300) {
 			cout << "elapsed sim time: " << sim->time() << " seconds" << endl;
 			cout << "number of loops: " << loop_counter << endl;
 			cout << "sim timestep was: " << sim->timestep() << " seconds"
@@ -50,13 +48,13 @@ int main() {
 			cout << "Pausing simulation" << endl << endl;
 			sim->pause();
 		}
-		if (loop_counter == 1000) {
+		if (loop_counter == 500) {
 			cout << "elapsed sim time: " << sim->time() << " seconds" << endl;
 			cout << "number of loops: " << loop_counter << endl;
 			cout << "unpausing simulation" << endl << endl;
 			sim->unpause();
 		}
-		if (loop_counter == 1500) {
+		if (loop_counter == 700) {
 			sim->resetWorld(world_file);
 			cout << endl
 				 << "elapsed sim time: " << sim->time() << " seconds" << endl;
@@ -65,7 +63,7 @@ int main() {
 				 << endl;
 			sim->setTimestep(0.05);
 		}
-		if (loop_counter == 2000) {
+		if (loop_counter == 900) {
 			cout << "elapsed sim time: " << sim->time() << " seconds" << endl;
 			cout << "number of loops: " << loop_counter << endl;
 			cout << "sim timestep was: " << sim->timestep() << " seconds"

--- a/examples/sai2/06-reset_world/main.cpp
+++ b/examples/sai2/06-reset_world/main.cpp
@@ -14,7 +14,6 @@ const string world_file_1 = "resources/world.urdf";
 const string world_file_2 = "resources/world2.urdf";
 
 unsigned long long simulation_counter = 0;
-Eigen::VectorXd q_robot;
 
 int main() {
 	// load simulation world
@@ -38,10 +37,9 @@ int main() {
 
 		// update graphics
 		for (const auto name : robot_names) {
-			sim->getJointPositions(name, q_robot);
-			graphics->updateRobotGraphics(name, q_robot);
+			graphics->updateRobotGraphics(name, sim->getJointPositions(name));
 		}
-		graphics->updateDisplayedWorld();
+		graphics->renderGraphicsWorld();
 
 		if (simulation_counter % 700 == 350) {
 			sim->resetWorld(world_file_2);

--- a/examples/sai2/06-reset_world/world.urdf
+++ b/examples/sai2/06-reset_world/world.urdf
@@ -6,7 +6,7 @@
 		<!-- model node is required -->
 		<model dir="resources" path="rbot.urdf" name="RBot_description" />
 		<!-- origin node is optional -->
-		<origin xyz="0.0 0.0 0.0" rpy="0.3 0 0" />
+		<origin xyz="0.0 0.0 0.0" rpy="0.5 0 0" />
 	</robot>
 
 	<static_object name="Floor">

--- a/examples/sai2/08-force_sensor/main.cpp
+++ b/examples/sai2/08-force_sensor/main.cpp
@@ -15,7 +15,6 @@ const string robot_name = "PPPBot";
 const string link_name = "sensor_link";
 
 unsigned long long simulation_counter = 0;
-Eigen::VectorXd q_robot;
 
 int main() {
 	cout << "Loading URDF world model file: " << world_file << endl;
@@ -39,8 +38,8 @@ int main() {
 	}
 
 	// offset a joint initial condition
-	sim->getJointPositions(robot_name, q_robot);
-	sim->setJointPosition(robot_name, 0, q_robot[0] + 0.5);
+	sim->setJointPosition(robot_name, 0,
+						  sim->getJointPositions(robot_name)[0] + 0.5);
 
 	sim->setCollisionRestitution(0);
 
@@ -49,16 +48,13 @@ int main() {
 		// update simulation
 		sim->integrate();
 
-		// update kinematic models
-		sim->getJointPositions(robot_name, q_robot);
-
-		// update graphics. this automatically waits for the correct amount of
-		// time
-		graphics->updateRobotGraphics(robot_name, q_robot);
+		// update graphics.
+		graphics->updateRobotGraphics(robot_name,
+									  sim->getJointPositions(robot_name));
 		for (const auto sensor_data : sim->getAllForceSensorData()) {
 			graphics->updateDisplayedForceSensor(sensor_data);
 		}
-		graphics->updateDisplayedWorld();
+		graphics->renderGraphicsWorld();
 
 		if (simulation_counter == 150) {
 			sim->setJointTorque(robot_name, 1, -70);

--- a/src/Sai2Simulation.cpp
+++ b/src/Sai2Simulation.cpp
@@ -65,7 +65,7 @@ void Sai2Simulation::resetWorld(const std::string& path_to_world_file,
 	}
 }
 
-std::vector<std::string> Sai2Simulation::getRobotNames() const {
+const std::vector<std::string> Sai2Simulation::getRobotNames() const {
 	std::vector<std::string> robot_names;
 	for (const auto& it : _robot_filenames) {
 		robot_names.push_back(it.first);
@@ -74,7 +74,7 @@ std::vector<std::string> Sai2Simulation::getRobotNames() const {
 }
 
 // get dof
-unsigned int Sai2Simulation::dof(const std::string& robot_name) const {
+const unsigned int Sai2Simulation::dof(const std::string& robot_name) const {
 	if (!existsInSimulatedWorld(robot_name)) {
 		throw std::invalid_argument(
 			"cannot get dof for robot [" + robot_name +
@@ -83,7 +83,7 @@ unsigned int Sai2Simulation::dof(const std::string& robot_name) const {
 	return _robot_models.at(robot_name)->dof();
 }
 
-unsigned int Sai2Simulation::qSize(const std::string& robot_name) const {
+const unsigned int Sai2Simulation::qSize(const std::string& robot_name) const {
 	if (!existsInSimulatedWorld(robot_name)) {
 		throw std::invalid_argument(
 			"cannot get dof for robot [" + robot_name +
@@ -134,7 +134,7 @@ void Sai2Simulation::setJointPositions(const std::string& robot_name,
 }
 
 // read joint positions
-Eigen::VectorXd Sai2Simulation::getJointPositions(
+const Eigen::VectorXd Sai2Simulation::getJointPositions(
 	const std::string& robot_name) const {
 	if (!existsInSimulatedWorld(robot_name)) {
 		throw std::invalid_argument(
@@ -164,7 +164,7 @@ Eigen::VectorXd Sai2Simulation::getJointPositions(
 }
 
 // read object pose
-Eigen::Affine3d Sai2Simulation::getObjectPose(
+const Eigen::Affine3d Sai2Simulation::getObjectPose(
 	const std::string& object_name) const {
 	if (!existsInSimulatedWorld(object_name)) {
 		throw std::invalid_argument(
@@ -287,7 +287,7 @@ void Sai2Simulation::setJointVelocity(const std::string& robot_name,
 }
 
 // read joint velocities
-Eigen::VectorXd Sai2Simulation::getJointVelocities(
+const Eigen::VectorXd Sai2Simulation::getJointVelocities(
 	const std::string& robot_name) const {
 	if (!existsInSimulatedWorld(robot_name)) {
 		throw std::invalid_argument(
@@ -314,7 +314,7 @@ Eigen::VectorXd Sai2Simulation::getJointVelocities(
 }
 
 // read object velocities
-Eigen::VectorXd Sai2Simulation::getObjectVelocity(
+const Eigen::VectorXd Sai2Simulation::getObjectVelocity(
 	const std::string& object_name) const {
 	if (!existsInSimulatedWorld(object_name)) {
 		throw std::invalid_argument(
@@ -390,7 +390,7 @@ void Sai2Simulation::setAllJointTorquesInternal() {
 }
 
 // read joint accelerations
-Eigen::VectorXd Sai2Simulation::getJointAccelerations(
+const Eigen::VectorXd Sai2Simulation::getJointAccelerations(
 	const std::string& robot_name) const {
 	if (!existsInSimulatedWorld(robot_name)) {
 		throw std::invalid_argument(
@@ -497,7 +497,7 @@ void Sai2Simulation::showLinksInContact(const std::string robot_name) {
 	}
 }
 
-std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>
+const std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>
 Sai2Simulation::getContactList(const ::std::string& robot_name,
 							   const std::string& link_name) const {
 	return _world->getContactList(robot_name, link_name);
@@ -524,7 +524,7 @@ void Sai2Simulation::addSimulatedForceSensor(
 		robot_name, link_name, transform_in_link, _robot_models[robot_name]));
 }
 
-Eigen::Vector3d Sai2Simulation::getSensedForce(
+const Eigen::Vector3d Sai2Simulation::getSensedForce(
 	const std::string& robot_name, const std::string& link_name,
 	const bool in_sensor_frame) const {
 	int sensor_index = findSimulatedForceSensor(robot_name, link_name);
@@ -540,7 +540,7 @@ Eigen::Vector3d Sai2Simulation::getSensedForce(
 	return _force_sensors.at(sensor_index)->getForceWorldFrame();
 }
 
-Eigen::Vector3d Sai2Simulation::getSensedMoment(
+const Eigen::Vector3d Sai2Simulation::getSensedMoment(
 	const std::string& robot_name, const std::string& link_name,
 	const bool in_sensor_frame) const {
 	int sensor_index = findSimulatedForceSensor(robot_name, link_name);
@@ -556,7 +556,7 @@ Eigen::Vector3d Sai2Simulation::getSensedMoment(
 	return _force_sensors.at(sensor_index)->getMomentWorldFrame();
 }
 
-std::vector<Sai2Model::ForceSensorData> Sai2Simulation::getAllForceSensorData()
+const std::vector<Sai2Model::ForceSensorData> Sai2Simulation::getAllForceSensorData()
 	const {
 	std::vector<Sai2Model::ForceSensorData> sensor_data;
 	for (const auto& sensor : _force_sensors) {
@@ -565,7 +565,7 @@ std::vector<Sai2Model::ForceSensorData> Sai2Simulation::getAllForceSensorData()
 	return sensor_data;
 }
 
-int Sai2Simulation::findSimulatedForceSensor(
+const int Sai2Simulation::findSimulatedForceSensor(
 	const std::string& robot_name, const std::string& link_name) const {
 	for (int i = 0; i < _force_sensors.size(); ++i) {
 		if ((_force_sensors.at(i)->getData()._robot_name == robot_name) &&
@@ -576,7 +576,7 @@ int Sai2Simulation::findSimulatedForceSensor(
 	return -1;
 }
 
-bool Sai2Simulation::existsInSimulatedWorld(const std::string& robot_name,
+const bool Sai2Simulation::existsInSimulatedWorld(const std::string& robot_name,
 											const std::string link_name) const {
 	auto robot = _world->getBaseNode(robot_name);
 	if (robot == NULL) {
@@ -624,13 +624,13 @@ void Sai2Simulation::setCollisionRestitution(const std::string& robot_name,
 	mat->setEpsilon(restitution);
 }
 
-double Sai2Simulation::getCollisionRestitution(
+const double Sai2Simulation::getCollisionRestitution(
 	const std::string& object_name) const {
 	return getCollisionRestitution(object_name, "object_link");
 }
 
 // get co-efficient of restitution: for a named robot and link
-double Sai2Simulation::getCollisionRestitution(
+const double Sai2Simulation::getCollisionRestitution(
 	const std::string& robot_name, const std::string& link_name) const {
 	if (!existsInSimulatedWorld(robot_name, link_name)) {
 		throw std::invalid_argument(
@@ -675,13 +675,13 @@ void Sai2Simulation::setCoeffFrictionStatic(const std::string& robot_name,
 	mat->setStaticFriction(static_friction);
 }
 
-double Sai2Simulation::getCoeffFrictionStatic(
+const double Sai2Simulation::getCoeffFrictionStatic(
 	const std::string& object_name) const {
 	return getCoeffFrictionStatic(object_name, "object_link");
 }
 
 // get co-efficient of static friction: for a named robot and link
-double Sai2Simulation::getCoeffFrictionStatic(
+const double Sai2Simulation::getCoeffFrictionStatic(
 	const std::string& robot_name, const std::string& link_name) const {
 	if (!existsInSimulatedWorld(robot_name, link_name)) {
 		throw std::invalid_argument(
@@ -726,13 +726,13 @@ void Sai2Simulation::setCoeffFrictionDynamic(const std::string& robot_name,
 	mat->setDynamicFriction(dynamic_friction);
 }
 
-double Sai2Simulation::getCoeffFrictionDynamic(
+const double Sai2Simulation::getCoeffFrictionDynamic(
 	const std::string& object_name) const {
 	return getCoeffFrictionDynamic(object_name, "object_link");
 }
 
 // get co-efficient of dynamic friction: for a named robot and link
-double Sai2Simulation::getCoeffFrictionDynamic(
+const double Sai2Simulation::getCoeffFrictionDynamic(
 	const std::string& robot_name, const std::string& link_name) const {
 	if (!existsInSimulatedWorld(robot_name, link_name)) {
 		throw std::invalid_argument(
@@ -746,7 +746,7 @@ double Sai2Simulation::getCoeffFrictionDynamic(
 }
 
 // get pose of robot base in the world frame
-Eigen::Affine3d Sai2Simulation::getRobotBaseTransform(
+const Eigen::Affine3d Sai2Simulation::getRobotBaseTransform(
 	const std::string& robot_name) const {
 	Eigen::Affine3d gToRobotBase;
 	const auto base = _world->getBaseNode(robot_name);

--- a/src/Sai2Simulation.h
+++ b/src/Sai2Simulation.h
@@ -77,28 +77,6 @@ public:
 						   const Eigen::VectorXd& q);
 
 	/**
-	 * @brief Read back joint positions as an array.
-	 * @param robot_name Name of the robot for which transaction is required.
-	 * @param q_ret Array to write back joint positions into.
-	 */
-	void getJointPositions(const std::string& robot_name,
-						   Eigen::VectorXd& q_ret) const;
-
-	/**
-	 * @brief Read back position and orientation of an object.
-	 * @param object_name Name of the object for which transaction is required.
-	 * @param pos Array to write back position into.
-	 * @param ori Quaternion to write back orientation into.
-	 */
-	void getObjectPosition(const std::string& object_name, Eigen::Vector3d& pos,
-						   Eigen::Quaterniond& ori) const;
-
-	// set object pose
-	void setObjectPosition(const std::string& object_name,
-						   const Eigen::Vector3d& pos,
-						   const Eigen::Quaterniond& ori) const;
-
-	/**
 	 * @brief Set joint position for a single joint
 	 * @param robot_name Name of the robot for which transaction is required.
 	 * @param joint_id Joint number on which to set value.
@@ -106,6 +84,24 @@ public:
 	 */
 	void setJointPosition(const std::string& robot_name, unsigned int joint_id,
 						  double position);
+
+	/**
+	 * @brief Read back joint positions as an array.
+	 * @param robot_name Name of the robot for which transaction is required.
+	 * @return joint positions for that robot.
+	 */
+	Eigen::VectorXd getJointPositions(const std::string& robot_name) const;
+
+	/**
+	 * @brief Read back position and orientation of an object.
+	 * @param object_name Name of the object for which transaction is required.
+	 * @return pose of that object.
+	 */
+	Eigen::Affine3d getObjectPose(const std::string& object_name) const;
+
+	// set object pose
+	void setObjectPose(const std::string& object_name,
+					   const Eigen::Affine3d& pose) const;
 
 	/**
 	 * @brief Set joint velocities as an array. Assumes serial or tree chain
@@ -126,22 +122,19 @@ public:
 						  double velocity);
 
 	/**
-	 * @brief Read back joint velocities as an array.
+	 * @brief Get the joint velocities for a robot.
 	 * @param robot_name Name of the robot for which transaction is required.
-	 * @param dq_ret Array to write back joint velocities into.
+	 * @return joint velocities for that robot.
 	 */
-	void getJointVelocities(const std::string& robot_name,
-							Eigen::VectorXd& dq_ret) const;
+	Eigen::VectorXd getJointVelocities(const std::string& robot_name) const;
 
 	/**
-	 * @brief Read back linear and angular velocities of an object.
+	 * @brief Read back linear and angular velocities of an object as a 6d
+	 * vector (linear first, angular second).
 	 * @param object_name Name of the object for which transaction is required.
-	 * @param lin_vel Array to write back linear velocity into.
-	 * @param ang_vel Array to write back angular velocity into.
+	 * @return a 6d vector containing [lin_vel, ang_vel].
 	 */
-	void getObjectVelocity(const std::string& object_name,
-						   Eigen::Vector3d& lin_vel,
-						   Eigen::Vector3d& ang_vel) const;
+	Eigen::VectorXd getObjectVelocity(const std::string& object_name) const;
 
 	/**
 	 * @brief Set joint torques as an array. Assumes serial or tree chain robot.
@@ -161,12 +154,11 @@ public:
 						double tau);
 
 	/**
-	 * @brief Read back joint accelerations as an array.
+	 * @brief Get the joint accelerations for a given robot.
 	 * @param robot_name Name of the robot for which transaction is required.
-	 * @param ddq_ret Array to write back joint accelerations into.
+	 * @return joint accelerations for that robot.
 	 */
-	void getJointAccelerations(const std::string& robot_name,
-							   Eigen::VectorXd& ddq_ret) const;
+	Eigen::VectorXd getJointAccelerations(const std::string& robot_name) const;
 
 	/**
 	 * @brief Integrate the virtual world over the time step (1ms by default or
@@ -187,18 +179,16 @@ public:
 	void showLinksInContact(const std::string robot_name);
 
 	/**
-	 * @brief      Gets a vector of contact points and the corresponding contact
-	 * forces at a gicen link of a given object. Gives everything in base frame.
+	 * @brief      Gets the list of contacts on a given robot at a given link
 	 *
-	 * @param      contact_points  The contact points vector to be returned
-	 * @param      contact_forces  The contact forces vector to be returned
 	 * @param[in]  robot_name      The robot name
 	 * @param[in]  link_name       The link name
+	 * @return  a vector of pairs, the first element of the pair contains the
+	 * location of the contact point in world coordinates, and the second
+	 * contains the contact force in world coordinates
 	 */
-	void getContactList(std::vector<Eigen::Vector3d>& contact_points,
-						std::vector<Eigen::Vector3d>& contact_forces,
-						const ::std::string& robot_name,
-						const std::string& link_name);
+	std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> getContactList(
+		const ::std::string& robot_name, const std::string& link_name) const;
 
 	void addSimulatedForceSensor(
 		const std::string& robot_name, const std::string& link_name,

--- a/src/Sai2Simulation.h
+++ b/src/Sai2Simulation.h
@@ -45,25 +45,25 @@ public:
 	 *        NOTE: Assumes serial or tree chain robot.
 	 * @param robot_name Name of the robot for which transaction is required.
 	 */
-	unsigned int dof(const std::string& robot_name) const;
-	unsigned int qSize(const std::string& robot_name) const;
+	const unsigned int dof(const std::string& robot_name) const;
+	const unsigned int qSize(const std::string& robot_name) const;
 
 	void resetWorld(const std::string& path_to_world_file,
 					bool verbose = false);
 
-	double timestep() const { return _timestep; }
+	const double& timestep() const { return _timestep; }
 	void setTimestep(const double dt);
 
-	double time() const { return _time; }
+	const double& time() const { return _time; }
 
-	double isPaused() const { return _is_paused; }
+	const bool& isPaused() const { return _is_paused; }
 	void pause() { _is_paused = true; }
 	void unpause() { _is_paused = false; }
 
 	void enableGravityCompensation(const bool enable) {
 		_gravity_compensation_enabled = enable;
 	}
-	bool isGravityCompensationEnabled() const {
+	const bool& isGravityCompensationEnabled() const {
 		return _gravity_compensation_enabled;
 	}
 
@@ -90,14 +90,14 @@ public:
 	 * @param robot_name Name of the robot for which transaction is required.
 	 * @return joint positions for that robot.
 	 */
-	Eigen::VectorXd getJointPositions(const std::string& robot_name) const;
+	const Eigen::VectorXd getJointPositions(const std::string& robot_name) const;
 
 	/**
 	 * @brief Read back position and orientation of an object.
 	 * @param object_name Name of the object for which transaction is required.
 	 * @return pose of that object.
 	 */
-	Eigen::Affine3d getObjectPose(const std::string& object_name) const;
+	const Eigen::Affine3d getObjectPose(const std::string& object_name) const;
 
 	// set object pose
 	void setObjectPose(const std::string& object_name,
@@ -126,7 +126,7 @@ public:
 	 * @param robot_name Name of the robot for which transaction is required.
 	 * @return joint velocities for that robot.
 	 */
-	Eigen::VectorXd getJointVelocities(const std::string& robot_name) const;
+	const Eigen::VectorXd getJointVelocities(const std::string& robot_name) const;
 
 	/**
 	 * @brief Read back linear and angular velocities of an object as a 6d
@@ -134,7 +134,7 @@ public:
 	 * @param object_name Name of the object for which transaction is required.
 	 * @return a 6d vector containing [lin_vel, ang_vel].
 	 */
-	Eigen::VectorXd getObjectVelocity(const std::string& object_name) const;
+	const Eigen::VectorXd getObjectVelocity(const std::string& object_name) const;
 
 	/**
 	 * @brief Set joint torques as an array. Assumes serial or tree chain robot.
@@ -158,7 +158,7 @@ public:
 	 * @param robot_name Name of the robot for which transaction is required.
 	 * @return joint accelerations for that robot.
 	 */
-	Eigen::VectorXd getJointAccelerations(const std::string& robot_name) const;
+	const Eigen::VectorXd getJointAccelerations(const std::string& robot_name) const;
 
 	/**
 	 * @brief Integrate the virtual world over the time step (1ms by default or
@@ -187,21 +187,21 @@ public:
 	 * location of the contact point in world coordinates, and the second
 	 * contains the contact force in world coordinates
 	 */
-	std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> getContactList(
+	const std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> getContactList(
 		const ::std::string& robot_name, const std::string& link_name) const;
 
 	void addSimulatedForceSensor(
 		const std::string& robot_name, const std::string& link_name,
 		const Eigen::Affine3d transform_in_link = Eigen::Affine3d::Identity());
 
-	Eigen::Vector3d getSensedForce(const std::string& robot_name,
+	const Eigen::Vector3d getSensedForce(const std::string& robot_name,
 								   const std::string& link_name,
 								   const bool in_sensor_frame = true) const;
-	Eigen::Vector3d getSensedMoment(const std::string& robot_name,
+	const Eigen::Vector3d getSensedMoment(const std::string& robot_name,
 									const std::string& link_name,
 									const bool in_sensor_frame = true) const;
 
-	std::vector<Sai2Model::ForceSensorData> getAllForceSensorData() const;
+	const std::vector<Sai2Model::ForceSensorData> getAllForceSensorData() const;
 
 	/* Sai2-Simulation specific interface */
 
@@ -238,7 +238,7 @@ public:
 	 * @param      object_name  Object from which to get the value
 	 * @return     Current value
 	 */
-	double getCollisionRestitution(const std::string& object_name) const;
+	const double getCollisionRestitution(const std::string& object_name) const;
 
 	/**
 	 * @brief      Get the co-efficient of kinematic restitution: for a named
@@ -247,7 +247,7 @@ public:
 	 * @param      link_name  Robot from which to get the value
 	 * @return     Current value
 	 */
-	double getCollisionRestitution(const std::string& robot_name,
+	const double getCollisionRestitution(const std::string& robot_name,
 								   const std::string& link_name) const;
 
 	/**
@@ -281,7 +281,7 @@ public:
 	 * @param      object_name  Robot from which to get the value
 	 * @return     Current value
 	 */
-	double getCoeffFrictionStatic(const std::string& object_name) const;
+	const double getCoeffFrictionStatic(const std::string& object_name) const;
 
 	/**
 	 * @brief      Get the co-efficient of static friction: for a named link on
@@ -290,7 +290,7 @@ public:
 	 * @param      link_name  Robot from which to get the value
 	 * @return     Current value
 	 */
-	double getCoeffFrictionStatic(const std::string& robot_name,
+	const double getCoeffFrictionStatic(const std::string& robot_name,
 								  const std::string& link_name) const;
 
 	/**
@@ -326,7 +326,7 @@ public:
 	 * @param      object_name  Robot from which to get the value
 	 * @return     Current value
 	 */
-	double getCoeffFrictionDynamic(const std::string& object_name) const;
+	const double getCoeffFrictionDynamic(const std::string& object_name) const;
 
 	/**
 	 * @brief      Get the co-efficient of dynamic friction: for a named link on
@@ -335,7 +335,7 @@ public:
 	 * @param      link_name  Robot from which to get the value
 	 * @return     Current value
 	 */
-	double getCoeffFrictionDynamic(const std::string& robot_name,
+	const double getCoeffFrictionDynamic(const std::string& robot_name,
 								   const std::string& link_name) const;
 
 	/**
@@ -344,19 +344,19 @@ public:
 	 * @param      robot_name  Robot from which to get the value
 	 * @return     Transform
 	 */
-	Eigen::Affine3d getRobotBaseTransform(const std::string& robot_name) const;
+	const Eigen::Affine3d getRobotBaseTransform(const std::string& robot_name) const;
 
-	const std::shared_ptr<cDynamicWorld> getDynamicWorld() const {
+	const std::shared_ptr<cDynamicWorld>& getDynamicWorld() const {
 		return _world;
 	}
 
-	std::vector<std::string> getRobotNames() const;
+	const std::vector<std::string> getRobotNames() const;
 
 private:
-	bool existsInSimulatedWorld(const std::string& robot_or_object_name,
+	const bool existsInSimulatedWorld(const std::string& robot_or_object_name,
 								const std::string link_name = "") const;
 
-	int findSimulatedForceSensor(const std::string& robot_name,
+	const int findSimulatedForceSensor(const std::string& robot_name,
 								 const std::string& link_name) const;
 
 	void setAllJointTorquesInternal();

--- a/src/chai3d/CDynamicWorld.cpp
+++ b/src/chai3d/CDynamicWorld.cpp
@@ -246,54 +246,58 @@ cDynamicBase* cDynamicWorld::getBaseNode(std::string a_name)
 
 //===========================================================================
 /*!
-    Get a list of contacts (location and force in world) for a given robot at a given list
+	Get a list of contacts (location and force in world) for a given robot at a
+   given list
 
-    \param  contact_points  Return vector of contact locations in world
-    \param  contact_forces  Return vector of contact forces in world
-    \param  robot_name  Name of the object
-    \param  link_name  Name of the link
+	\param  robot_name  Name of the object
+	\param  link_name  Name of the link
+
+	\return a vector of pairs containing the location of the contact point
+   (first) and the contact force (second) expressed in world frame
+
 */
 //===========================================================================
-void cDynamicWorld::getContactList(std::vector<Eigen::Vector3d>& contact_points,
-                                   std::vector<Eigen::Vector3d>& contact_forces,
-                                   const ::std::string& robot_name,
-                                   const std::string& link_name) const {
-	contact_points.clear();
-	contact_forces.clear();
+std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>>
+cDynamicWorld::getContactList(const ::std::string& robot_name,
+							  const std::string& link_name) const {
+	std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> contact_list;
 	Eigen::Vector3d current_position = Eigen::Vector3d::Zero();
 	Eigen::Vector3d current_force = Eigen::Vector3d::Zero();
 
-    for(auto i = m_dynamicObjects.begin(); i != m_dynamicObjects.end(); ++i)
-    {
-    	cDynamicBase* object = *i;
-    	// only consider the desired object
-    	if(object->m_name != robot_name)
-    	{
-    		continue;
-    	}
-    	int num_contacts = object->m_dynamicContacts->getNumContacts();
-    	// only consider if the oject is contacting something
-        if(num_contacts > 0)
-        {
-        	for(int k=0; k < num_contacts; k++)
-	    	{
-	        	cDynamicContact* contact = object->m_dynamicContacts->getContact(k);
-	        	// only consider contacts at the desired link
-                if(contact==NULL || contact->m_dynamicLink->m_name != link_name)
-	        	{
-	        		continue;
-	        	}
-	        	// copy chai3d vector to eigen vector
-	        	for(int l=0; l<3; l++)
-	        	{
-		        	current_position(l) = contact->m_globalPos(l);
-		        	// the friction force is inverted for some reason. Need to substract it to get a coherent result.
-		        	current_force(l) = contact->m_globalNormalForce(l) - contact->m_globalFrictionForce(l);
-	        	}
-	        	// reverse the sign to get the list of forces applied to the considered object
-	        	contact_points.push_back(current_position);
-	        	contact_forces.push_back(-current_force);
-	        }
-        }
-    }
+	for (auto i = m_dynamicObjects.begin(); i != m_dynamicObjects.end(); ++i) {
+		cDynamicBase* object = *i;
+		// only consider the desired object
+		if (object->m_name != robot_name) {
+			continue;
+		}
+		int num_contacts = object->m_dynamicContacts->getNumContacts();
+		// only consider if the oject is contacting something
+		if (num_contacts > 0) {
+			for (int k = 0; k < num_contacts; k++) {
+				cDynamicContact* contact =
+					object->m_dynamicContacts->getContact(k);
+				// only consider contacts at the desired link
+				if (contact == NULL ||
+					contact->m_dynamicLink->m_name != link_name) {
+					continue;
+				}
+				// copy chai3d vector to eigen vector
+				for (int l = 0; l < 3; l++) {
+					current_position(l) = contact->m_globalPos(l);
+					// the friction force is inverted for some reason. Need to
+					// substract it to get a coherent result.
+					current_force(l) = contact->m_globalNormalForce(l) -
+									   contact->m_globalFrictionForce(l);
+				}
+				// reverse the sign to get the list of forces applied to the
+				// considered object
+				contact_list.push_back(
+					std::make_pair(current_position, -current_force));
+			}
+		}
+        return contact_list;
+	}
+	// to suppress warning, and return an empty vector in the case there are no
+	// objects in the world
+	return contact_list;
 }

--- a/src/chai3d/CDynamicWorld.h
+++ b/src/chai3d/CDynamicWorld.h
@@ -83,13 +83,11 @@ public:
     //! Get collision detection update rate.
     double getCollisionRate() { return (m_dynWorld->collisionStep()); };
 
-    //! get contact list for a given robot at a given link
-    void getContactList(std::vector<Eigen::Vector3d>& contact_points,
-                        std::vector<Eigen::Vector3d>& contact_forces,
-                        const ::std::string& robot_name,
-                        const std::string& link_name) const;
+	//! get contact list for a given robot at a given link
+	std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> getContactList(
+		const ::std::string& robot_name, const std::string& link_name) const;
 
-    //-----------------------------------------------------------------------
+	//-----------------------------------------------------------------------
     // PUBLIC METHODS: (Graphics)
     //-----------------------------------------------------------------------
 


### PR DESCRIPTION
Populating parameters as was done before can be problematic when using the simulation and visualizer or controller on separate threads. If we are trying to populate a vector (like the object position) in the simulation and display it in the graphics in a separate thread, it can lead to visual glitches. 
In contrast, returning Eigen objects can be used in a more thread safe way.
In addition, returning values makes it more natural to use in the applications.